### PR TITLE
fix: specify trigger type for daily notifications

### DIFF
--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -1,10 +1,15 @@
 import * as Notifications from 'expo-notifications';
+import { SchedulableTriggerInputTypes } from 'expo-notifications';
 
 export async function scheduleDailyReviewNotification() {
   const { status } = await Notifications.requestPermissionsAsync();
   if (status !== 'granted') return;
   await Notifications.scheduleNotificationAsync({
     content: { title: '復習の時間です' },
-    trigger: { seconds: 24 * 60 * 60, repeats: true },
+    trigger: {
+      type: SchedulableTriggerInputTypes.TIME_INTERVAL,
+      seconds: 24 * 60 * 60,
+      repeats: true,
+    },
   });
 }


### PR DESCRIPTION
## Summary
- provide explicit trigger type for daily review notifications so TS compile

## Testing
- `npx tsc -p apps/mobile/tsconfig.json`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6ec20caa883288d0f825f679aea0f