### PR TITLE
fix: configure workspace module resolution

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,0 +1,18 @@
+const { getDefaultConfig } = require('expo/metro-config');
+const path = require('path');
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, '../..');
+
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [workspaceRoot];
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(workspaceRoot, 'node_modules'),
+];
+config.resolver.alias = {
+  '@ares-kakomon/core': path.resolve(workspaceRoot, 'packages/core/src'),
+};
+
+module.exports = config;

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@ares-kakomon/core": ["../../packages/core/src"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add metro configuration with alias for core package
- map `@ares-kakomon/core` in mobile TypeScript config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7225299b88328b99a9133493be918